### PR TITLE
feat: Enhance Docker support and add sandbox service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,29 @@ format: ## Format code and organize imports with ruff
 .PHONY: quality
 quality: format lint-fix ## Run all quality checks
 	@echo "$(GREEN)All quality checks completed!$(NC)"
+
+# =============================================================================
+# DOCKER
+# =============================================================================
+
+.PHONY: docker-build-sandbox
+docker-build-sandbox: ## Build the custom Python sandbox Docker image with preinstalled libraries
+	@echo "$(BLUE)Building custom Python sandbox image...$(NC)"
+	docker build -f docker/Dockerfile.sandbox -t aipg-sandbox:latest .
+	@echo "$(GREEN)Sandbox image built successfully!$(NC)"
+
+.PHONY: docker-build-api
+docker-build-api: ## Build the API Docker image
+	@echo "$(BLUE)Building API image...$(NC)"
+	docker build -f docker/Dockerfile.api -t aipg-api:latest .
+	@echo "$(GREEN)API image built successfully!$(NC)"
+
+.PHONY: docker-build-frontend
+docker-build-frontend: ## Build the frontend Docker image
+	@echo "$(BLUE)Building frontend image...$(NC)"
+	docker build -f docker/Dockerfile.frontend -t aipg-frontend:latest .
+	@echo "$(GREEN)Frontend image built successfully!$(NC)"
+
+.PHONY: docker-build
+docker-build: docker-build-sandbox docker-build-api docker-build-frontend ## Build all Docker images
+	@echo "$(GREEN)All Docker images built successfully!$(NC)"

--- a/README.md
+++ b/README.md
@@ -138,9 +138,126 @@ result = service.run_code("print('hello')")
 print(result.stdout)
 ```
 
+#### Preinstalled Libraries
+
+The sandbox includes a custom Docker image with preinstalled Python libraries:
+
+- **pandas** - Data manipulation and analysis
+- **numpy** - Numerical computing
+- **torch** - Machine learning framework
+- **scikit-learn** - Machine learning library
+- **matplotlib** - Plotting library
+- **requests** - HTTP library
+- **beautifulsoup4** - HTML/XML parsing
+- **lxml** - XML processing
+
+To use the custom image with preinstalled libraries:
+
+```python
+from aipg.sandbox.builder import build_sandbox_service
+from aipg.configs.app_config import AppConfig
+
+# Load configuration (includes sandbox settings)
+config = AppConfig()
+service = build_sandbox_service(config)
+
+# Now you can use preinstalled libraries
+result = service.run_code("""
+import pandas as pd
+import numpy as np
+import torch
+
+df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+print('DataFrame shape:', df.shape)
+
+arr = np.array([1, 2, 3, 4, 5])
+print('Array sum:', arr.sum())
+
+tensor = torch.tensor([1.0, 2.0, 3.0])
+print('Tensor mean:', tensor.mean().item())
+""")
+print(result.stdout)
+```
+
+#### Building Docker Images
+
+The project includes several Docker images that can be built using make targets:
+
+```bash
+# Build all Docker images
+make docker-build
+
+# Build individual images
+make docker-build-sandbox    # Custom Python sandbox with preinstalled libraries
+make docker-build-api        # API server image
+make docker-build-frontend   # Frontend React application image
+```
+
+Or build manually:
+
+```bash
+# Sandbox image with preinstalled libraries
+docker build -f docker/Dockerfile.sandbox -t aipg-sandbox:latest .
+
+# API server image
+docker build -f docker/Dockerfile.api -t aipg-api:latest .
+
+# Frontend image
+docker build -f docker/Dockerfile.frontend -t aipg-frontend:latest .
+```
+
+#### Configuration
+
+Sandbox settings can be configured in `aipg/configs/default.yaml`:
+
+```yaml
+sandbox:
+  docker_image: "aipg-sandbox:latest"  # Custom image with preinstalled libraries
+  memory_limit: "128m"
+  cpu_quota: 0.5
+  pids_limit: 128
+  default_timeout_seconds: 5
+```
+
 Notes:
 - Requires Docker to be installed and the current user able to run `docker`.
 - The adapter runs with `--network none`, `--read-only`, memory/CPU limits, and non-root user.
+- The custom image is based on `python:3.12-slim` for compatibility with all preinstalled libraries.
+
+## 🐳 Docker Deployment
+
+The project includes a complete Docker setup for production deployment:
+
+### Using Docker Compose
+
+```bash
+# Build all images and start services
+docker-compose up --build
+
+# Run in detached mode
+docker-compose up -d --build
+
+# Stop services
+docker-compose down
+```
+
+This will start:
+- **API server** on port 8000
+- **Frontend** on port 80 (nginx)
+- **Sandbox service** (internal)
+
+### Individual Container Usage
+
+```bash
+# Run API server
+docker run -p 8000:8000 aipg-api:latest
+
+# Run frontend
+docker run -p 80:80 aipg-frontend:latest
+
+# Run sandbox (for testing)
+docker run --rm aipg-sandbox:latest python -c "import pandas; print('pandas available')"
+```
 
 ## 🎓 About
 

--- a/aipg/configs/app_config.py
+++ b/aipg/configs/app_config.py
@@ -39,6 +39,14 @@ class RagConfig(BaseModel):
     embedding_api_key: Optional[str] = None
 
 
+class SandboxConfig(BaseModel):
+    docker_image: str = "python:3.12-alpine"
+    memory_limit: str = "128m"
+    cpu_quota: Optional[float] = 0.5
+    pids_limit: int = 128
+    default_timeout_seconds: int = 5
+
+
 class AppConfig(BaseModel):
     llm: LLMConfig = Field(default_factory=LLMConfig)
     langfuse: LangfuseConfig = Field(default_factory=LangfuseConfig)
@@ -47,3 +55,4 @@ class AppConfig(BaseModel):
     project_correction_attempts: int = 3
     session_id: str = Field(default_factory=lambda: uuid4().hex)
     rag: RagConfig = RagConfig()
+    sandbox: SandboxConfig = Field(default_factory=SandboxConfig)

--- a/aipg/configs/default.yaml.example
+++ b/aipg/configs/default.yaml.example
@@ -23,3 +23,9 @@ rag:
   embedding_model: ${oc.env:AIPG_RAG_EMBEDDING_MODEL, gemini-embedding-001}
   embedding_base_url: ${oc.env:AIPG_RAG_EMBEDDING_BASE_URL, null}
   embedding_api_key: ${oc.env:AIPG_RAG_EMBEDDING_API_KEY, null}
+sandbox:
+  docker_image: ${oc.env:AIPG_SANDBOX_DOCKER_IMAGE, aipg-sandbox:latest}
+  memory_limit: ${oc.env:AIPG_SANDBOX_MEMORY_LIMIT, 128m}
+  cpu_quota: ${oc.env:AIPG_SANDBOX_CPU_QUOTA, 0.5}
+  pids_limit: ${oc.env:AIPG_SANDBOX_PIDS_LIMIT, 128}
+  default_timeout_seconds: ${oc.env:AIPG_SANDBOX_DEFAULT_TIMEOUT_SECONDS, 5}

--- a/aipg/prompting/utils.py
+++ b/aipg/prompting/utils.py
@@ -5,8 +5,8 @@ import re
 from typing import Any, Dict, Iterable, Optional
 
 import json_repair
-from pydantic import ValidationError
 import yaml
+from pydantic import ValidationError
 
 from aipg.exceptions import OutputParserException
 from aipg.state import Project, ProjectValidationResult

--- a/aipg/sandbox/__init__.py
+++ b/aipg/sandbox/__init__.py
@@ -5,4 +5,3 @@ __all__ = [
     "SandboxResult",
     "PythonSandboxService",
 ]
-

--- a/aipg/sandbox/builder.py
+++ b/aipg/sandbox/builder.py
@@ -1,0 +1,22 @@
+"""Builder for creating sandbox services with configuration."""
+
+from __future__ import annotations
+
+from aipg.configs.app_config import AppConfig
+from aipg.sandbox.adapters import DockerPythonRunner
+from aipg.sandbox.service import PythonSandboxService
+
+
+def build_sandbox_service(config: AppConfig) -> PythonSandboxService:
+    """Build a configured sandbox service.
+
+    Args:
+        config: Application configuration containing sandbox settings.
+
+    Returns:
+        Configured PythonSandboxService instance.
+    """
+    runner = DockerPythonRunner(config=config.sandbox)
+    return PythonSandboxService(
+        runner=runner, default_timeout_seconds=config.sandbox.default_timeout_seconds
+    )

--- a/aipg/sandbox/domain.py
+++ b/aipg/sandbox/domain.py
@@ -17,4 +17,3 @@ class SandboxError(Exception):
 
 class SandboxTimeoutError(SandboxError):
     """Raised when the sandboxed execution times out."""
-

--- a/aipg/sandbox/ports.py
+++ b/aipg/sandbox/ports.py
@@ -6,5 +6,6 @@ from .domain import SandboxResult
 
 
 class SandboxRunner(Protocol):
-    def run(self, code: str, input_data: Optional[str], timeout_seconds: int) -> SandboxResult: ...
-
+    def run(
+        self, code: str, input_data: Optional[str], timeout_seconds: int
+    ) -> SandboxResult: ...

--- a/aipg/sandbox/service.py
+++ b/aipg/sandbox/service.py
@@ -17,13 +17,21 @@ class PythonSandboxService:
         self._runner = runner
         self._default_timeout_seconds = default_timeout_seconds
 
-    def run_code(self, code: str, input_data: Optional[str] = None, timeout_seconds: Optional[int] = None) -> SandboxResult:
+    def run_code(
+        self,
+        code: str,
+        input_data: Optional[str] = None,
+        timeout_seconds: Optional[int] = None,
+    ) -> SandboxResult:
         if not isinstance(code, str) or code.strip() == "":
             raise ValueError("code must be a non-empty string")
 
         effective_timeout = (
-            self._default_timeout_seconds if timeout_seconds is None else int(timeout_seconds)
+            self._default_timeout_seconds
+            if timeout_seconds is None
+            else int(timeout_seconds)
         )
 
-        return self._runner.run(code=code, input_data=input_data, timeout_seconds=effective_timeout)
-
+        return self._runner.run(
+            code=code, input_data=input_data, timeout_seconds=effective_timeout
+        )

--- a/aipg/state.py
+++ b/aipg/state.py
@@ -1,13 +1,16 @@
 from pydantic import BaseModel, Field
 
+
 class ProjectValidationCheck(BaseModel):
     rule_id: str
     passed: bool
     comment: str
 
+
 class ProjectValidationResult(BaseModel):
     is_valid: bool
     checks: list[ProjectValidationCheck]
+
 
 class Project(BaseModel):
     raw_markdown: str

--- a/aipg/task_inference/task_inference.py
+++ b/aipg/task_inference/task_inference.py
@@ -328,7 +328,7 @@ class ProjectValidatorInference(TaskInference[ProcessTopicAgentState]):
         if state.project is None:
             logger.warning("No project available for validation")
             return state
-        
+
         self.prompt_generator = ProjectValidatorPromptGenerator(
             project_markdown=state.project.raw_markdown
         )
@@ -387,13 +387,15 @@ class ProjectCorrectorInference(TaskInference[ProcessTopicAgentState]):
         if state.project is None or state.validation_result is None:
             logger.warning("No project or validation result available for correction")
             return state
-        
+
         # Prepare a YAML report from validation_result for the corrector LLM
-        validation_report = format_project_validation_result_yaml(state.validation_result)
+        validation_report = format_project_validation_result_yaml(
+            state.validation_result
+        )
 
         self.prompt_generator = ProjectCorrectorPromptGenerator(
             source_project=state.project.raw_markdown,
-            validation_report=validation_report
+            validation_report=validation_report,
         )
         chat_prompt = self.prompt_generator.generate_chat_prompt()
         last_exception: OutputParserException | None = None

--- a/docker/Dockerfile.sandbox
+++ b/docker/Dockerfile.sandbox
@@ -1,0 +1,36 @@
+# Custom Python sandbox image with preinstalled libraries
+FROM python:3.12-slim
+
+# Install system dependencies required for the Python packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    libc6-dev \
+    libffi-dev \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python packages
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir \
+    pandas \
+    numpy \
+    torch \
+    scikit-learn \
+    matplotlib \
+    requests \
+    beautifulsoup4 \
+    lxml
+
+# Create a non-root user for security
+RUN useradd -m -s /bin/bash sandbox
+
+# Switch to non-root user
+USER sandbox
+
+# Set working directory
+WORKDIR /home/sandbox
+
+# Default command
+CMD ["python"]

--- a/tests/sandbox/test_preinstalled_libraries.py
+++ b/tests/sandbox/test_preinstalled_libraries.py
@@ -1,0 +1,119 @@
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from aipg.configs.app_config import AppConfig, SandboxConfig
+
+pytestmark = pytest.mark.integration
+
+
+def _docker_available() -> bool:
+    docker_path = shutil.which("docker")
+    return docker_path is not None and os.access(docker_path, os.X_OK)
+
+
+def _custom_image_available() -> bool:
+    """Check if the custom sandbox image is available."""
+    if not _docker_available():
+        return False
+    try:
+        result = subprocess.run(
+            ["docker", "images", "-q", "aipg-sandbox:latest"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return bool(result.stdout.strip())
+    except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
+        return False
+
+
+@pytest.mark.skipif(not _docker_available(), reason="Docker CLI not available")
+@pytest.mark.skipif(
+    not _custom_image_available(), reason="Custom sandbox image not built"
+)
+def test_preinstalled_libraries_available():
+    """Test that preinstalled libraries (pandas, numpy, torch) are available in the custom image."""
+    from aipg.sandbox.builder import build_sandbox_service
+
+    # Arrange: create config with custom image
+    sandbox_config = SandboxConfig(
+        docker_image="aipg-sandbox:latest", default_timeout_seconds=10
+    )
+    config = AppConfig(sandbox=sandbox_config)
+    service = build_sandbox_service(config)
+
+    # Test pandas
+    result = service.run_code(
+        "import pandas as pd; print('pandas version:', pd.__version__)"
+    )
+    assert result.exit_code == 0
+    assert "pandas version:" in result.stdout
+
+    # Test numpy
+    result = service.run_code(
+        "import numpy as np; print('numpy version:', np.__version__)"
+    )
+    assert result.exit_code == 0
+    assert "numpy version:" in result.stdout
+
+    # Test torch
+    result = service.run_code(
+        "import torch; print('torch version:', torch.__version__)"
+    )
+    assert result.exit_code == 0
+    assert "torch version:" in result.stdout
+
+
+@pytest.mark.skipif(not _docker_available(), reason="Docker CLI not available")
+@pytest.mark.skipif(
+    not _custom_image_available(), reason="Custom sandbox image not built"
+)
+def test_preinstalled_libraries_functionality():
+    """Test that preinstalled libraries work correctly."""
+    from aipg.sandbox.builder import build_sandbox_service
+
+    # Arrange: create config with custom image
+    sandbox_config = SandboxConfig(
+        docker_image="aipg-sandbox:latest", default_timeout_seconds=10
+    )
+    config = AppConfig(sandbox=sandbox_config)
+    service = build_sandbox_service(config)
+
+    # Test pandas DataFrame creation
+    code = """
+import pandas as pd
+df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+print('DataFrame shape:', df.shape)
+print('Sum of column A:', df['A'].sum())
+"""
+    result = service.run_code(code)
+    assert result.exit_code == 0
+    assert "DataFrame shape: (3, 2)" in result.stdout
+    assert "Sum of column A: 6" in result.stdout
+
+    # Test numpy array operations
+    code = """
+import numpy as np
+arr = np.array([1, 2, 3, 4, 5])
+print('Array sum:', arr.sum())
+print('Array mean:', arr.mean())
+"""
+    result = service.run_code(code)
+    assert result.exit_code == 0
+    assert "Array sum: 15" in result.stdout
+    assert "Array mean: 3.0" in result.stdout
+
+    # Test torch tensor operations
+    code = """
+import torch
+tensor = torch.tensor([1.0, 2.0, 3.0])
+print('Tensor sum:', tensor.sum().item())
+print('Tensor mean:', tensor.mean().item())
+"""
+    result = service.run_code(code)
+    assert result.exit_code == 0
+    assert "Tensor sum: 6.0" in result.stdout
+    assert "Tensor mean: 2.0" in result.stdout

--- a/tests/sandbox/test_python_sandbox_integration.py
+++ b/tests/sandbox/test_python_sandbox_integration.py
@@ -1,15 +1,14 @@
 import os
 import shutil
-import subprocess
 
 import pytest
-
 
 pytestmark = pytest.mark.integration
 
 
 def _docker_available() -> bool:
-    return shutil.which("docker") is not None and os.access(shutil.which("docker"), os.X_OK)
+    docker_path = shutil.which("docker")
+    return docker_path is not None and os.access(docker_path, os.X_OK)
 
 
 @pytest.mark.skipif(not _docker_available(), reason="Docker CLI not available")
@@ -17,8 +16,9 @@ def test_docker_runner_executes_basic_code():
     from aipg.sandbox.adapters import DockerPythonRunner
     from aipg.sandbox.service import PythonSandboxService
 
-    service = PythonSandboxService(runner=DockerPythonRunner(), default_timeout_seconds=5)
+    service = PythonSandboxService(
+        runner=DockerPythonRunner(), default_timeout_seconds=5
+    )
     result = service.run_code("print('ok')")
     assert result.exit_code == 0
     assert "ok" in result.stdout
-

--- a/tests/sandbox/test_python_sandbox_service.py
+++ b/tests/sandbox/test_python_sandbox_service.py
@@ -1,7 +1,7 @@
-import pytest
 from dataclasses import dataclass
-from typing import Protocol, Optional
+from typing import Optional, Protocol
 
+import pytest
 
 # The tests operate as a black box around the service API.
 # We define minimal local Protocols/DTOs mirroring the public contract
@@ -17,14 +17,18 @@ class SandboxResult:
 
 
 class SandboxRunner(Protocol):
-    def run(self, code: str, input_data: Optional[str], timeout_seconds: int) -> SandboxResult: ...
+    def run(
+        self, code: str, input_data: Optional[str], timeout_seconds: int
+    ) -> SandboxResult: ...
 
 
 class FakeRunner:
     def __init__(self, result: SandboxResult):
         self._result = result
 
-    def run(self, code: str, input_data: Optional[str], timeout_seconds: int) -> SandboxResult:
+    def run(
+        self, code: str, input_data: Optional[str], timeout_seconds: int
+    ) -> SandboxResult:
         return self._result
 
 
@@ -61,4 +65,3 @@ def test_service_raises_value_error_on_empty_code():
 
     with pytest.raises(ValueError):
         service.run_code("")
-

--- a/tests/sandbox/test_sandbox_builder.py
+++ b/tests/sandbox/test_sandbox_builder.py
@@ -1,0 +1,51 @@
+import pytest
+
+from aipg.configs.app_config import AppConfig, SandboxConfig
+
+
+@pytest.mark.unit
+def test_build_sandbox_service_uses_config():
+    """Test that the builder creates a service with the correct configuration."""
+    from aipg.sandbox.builder import build_sandbox_service
+
+    # Arrange: create a mock config with custom sandbox settings
+    sandbox_config = SandboxConfig(
+        docker_image="custom-python:latest",
+        memory_limit="256m",
+        cpu_quota=1.0,
+        pids_limit=256,
+        default_timeout_seconds=10,
+    )
+    config = AppConfig(sandbox=sandbox_config)
+
+    # Act
+    service = build_sandbox_service(config)
+
+    # Assert: verify the service is created with the correct configuration
+    assert service is not None
+    assert service._default_timeout_seconds == 10
+    # The runner should be configured with the custom settings
+    assert service._runner._image == "custom-python:latest"
+    assert service._runner._memory_limit == "256m"
+    assert service._runner._cpu_quota == 1.0
+    assert service._runner._pids_limit == 256
+
+
+@pytest.mark.unit
+def test_build_sandbox_service_with_default_config():
+    """Test that the builder works with default configuration."""
+    from aipg.sandbox.builder import build_sandbox_service
+
+    # Arrange: use default config
+    config = AppConfig()
+
+    # Act
+    service = build_sandbox_service(config)
+
+    # Assert: verify the service is created with default settings
+    assert service is not None
+    assert service._default_timeout_seconds == 5  # default from SandboxConfig
+    assert service._runner._image == "python:3.12-alpine"  # default from SandboxConfig
+    assert service._runner._memory_limit == "128m"
+    assert service._runner._cpu_quota == 0.5
+    assert service._runner._pids_limit == 128

--- a/tests/task_inference/test_project_validator_inference.py
+++ b/tests/task_inference/test_project_validator_inference.py
@@ -8,9 +8,7 @@ from aipg.state import ProcessTopicAgentState, Project, ProjectValidationResult
 from aipg.task_inference.task_inference import ProjectValidatorInference
 
 
-def create_project(
-    topic: str, project_data: dict[str, Any] | None = None
-) -> Project:
+def create_project(topic: str, project_data: dict[str, Any] | None = None) -> Project:
     """Factory function to create Project objects for testing."""
     default_project_data = {
         "raw_markdown": f"# {topic}\n\nDescription: Test project for {topic}",
@@ -22,7 +20,7 @@ def create_project(
         "expert_solution": f"expert_solution_{topic}",
         "autotest": f"autotest_{topic}",
     }
-    
+
     if project_data is not None:
         default_project_data.update(project_data)
 
@@ -73,7 +71,11 @@ checks:
             {
                 "is_valid": False,
                 "checks": [
-                    {"rule_id": "SOLVABILITY", "passed": False, "comment": "Missing required data in input"},
+                    {
+                        "rule_id": "SOLVABILITY",
+                        "passed": False,
+                        "comment": "Missing required data in input",
+                    },
                     {"rule_id": "AUTOTEST_SCOPE", "passed": True, "comment": "OK"},
                 ],
             },
@@ -96,7 +98,11 @@ checks:
                 "is_valid": True,
                 "checks": [
                     {"rule_id": "SOLVABILITY", "passed": True, "comment": "OK"},
-                    {"rule_id": "AUTOTEST_SCOPE", "passed": True, "comment": "No autotest provided"},
+                    {
+                        "rule_id": "AUTOTEST_SCOPE",
+                        "passed": True,
+                        "comment": "No autotest provided",
+                    },
                 ],
             },
         ),
@@ -114,10 +120,9 @@ async def test_project_validator_inference_success(
 
     # Create a Project object using the factory
     project = create_project(
-        topic="test topic",
-        project_data={"raw_markdown": project_markdown}
+        topic="test topic", project_data={"raw_markdown": project_markdown}
     )
-    
+
     state = ProcessTopicAgentState(topic="test topic", project=project)
     inference = ProjectValidatorInference(llm=mock_llm)
 
@@ -145,7 +150,7 @@ async def test_project_validator_inference_max_retries_exceeded() -> None:
     mock_llm.query.return_value = "invalid response"
 
     project = create_project(topic="test topic")
-    
+
     state = ProcessTopicAgentState(topic="test topic", project=project)
     inference = ProjectValidatorInference(llm=mock_llm)
 
@@ -173,7 +178,7 @@ checks:
 ```"""
 
     project = create_project(topic="test topic")
-    
+
     state = ProcessTopicAgentState(topic="test topic", project=project)
     inference = ProjectValidatorInference(llm=mock_llm)
 
@@ -203,7 +208,7 @@ async def test_project_validator_inference_empty_response() -> None:
     mock_llm.query.return_value = ""
 
     project = create_project(topic="test topic")
-    
+
     state = ProcessTopicAgentState(topic="test topic", project=project)
     inference = ProjectValidatorInference(llm=mock_llm)
 
@@ -219,7 +224,7 @@ async def test_project_validator_inference_empty_response() -> None:
 async def test_project_validator_inference_no_project() -> None:
     """Test that ProjectValidatorInference handles state with no project correctly."""
     mock_llm = AsyncMock()
-    
+
     state = ProcessTopicAgentState(topic="test topic", project=None)
     inference = ProjectValidatorInference(llm=mock_llm)
 


### PR DESCRIPTION
- Introduced new Makefile targets for building Docker images for sandbox, API, and frontend.
- Added a custom Python sandbox Docker image with preinstalled libraries.
- Implemented a sandbox service builder to configure and run the sandbox environment.
- Updated README with instructions for building Docker images and using the sandbox service.
- Added integration tests to verify the availability and functionality of preinstalled libraries in the sandbox.