### PR TITLE
Start docker compose and fix frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.api
+      network: host
     env_file:
       - .env
     environment:
@@ -12,8 +13,7 @@ services:
     expose:
       - "8000"
     restart: unless-stopped
-    networks:
-      - app
+    network_mode: "host"
     volumes:
       - api_data:/app/data
       - cache_data:/app/aipg/cache
@@ -33,9 +33,9 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.sandbox
+      network: host
     restart: unless-stopped
-    networks:
-      - app
+    network_mode: "host"
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -57,16 +57,14 @@ services:
       dockerfile: docker/Dockerfile.frontend
       args:
         - VITE_API_BASE=/api
+      network: host
     depends_on:
       api:
         condition: service_healthy
-    ports:
-      - "80:80"
+    network_mode: "host"
     restart: unless-stopped
-    networks:
-      - app
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost/", "||", "exit", "1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -20,7 +20,7 @@ server {
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
-        proxy_pass http://api:8000/;
+        proxy_pass http://localhost:8000/;
     }
 
     # SPA fallback


### PR DESCRIPTION
Fix frontend container issues by configuring host networking, updating Nginx proxy, correcting the healthcheck, and adding a missing utility file.

The environment lacked full Docker daemon capabilities (e.g., no systemd, iptables), making host networking a necessary workaround. This change required updating the Nginx proxy to `localhost`. Additionally, the frontend build was failing due to a missing utility file and an incorrect healthcheck format.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d9be1ad-0bb7-4f40-b1a6-35ee893e6e40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d9be1ad-0bb7-4f40-b1a6-35ee893e6e40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

